### PR TITLE
Bug Fix: get template with windows path

### DIFF
--- a/app/templates/services/templatePath.js
+++ b/app/templates/services/templatePath.js
@@ -2,7 +2,7 @@ var path = require("path");
 
 module.exports = {
     getFilenameByRoute: function(routePath, extension) {
-        var filename = path.normalize(routePath).replace(/\/$/, "") + "." + extension;
+        var filename = path.normalize(routePath).replace(/[\/\\]$/, "") + "." + extension;
 
         return filename;
     }


### PR DESCRIPTION
Fixed problem for to find templates on routes with end equal to '/'
